### PR TITLE
chore(scripts): use zx built-in minimist to parse options

### DIFF
--- a/scripts/reset.js
+++ b/scripts/reset.js
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
 
-import {$} from 'zx';
+import {$, minimist} from 'zx';
 import {roots} from './nx.js';
-import process from "node:process";
+import process from 'node:process';
 
-const FLAGS = process.argv.slice(2).filter((arg) => /^-/.test(arg));
 const ROOTS = await roots();
-
-const metapackage = FLAGS.includes('--metapackage') || FLAGS.includes('-u');
+const flags = minimist(process.argv.slice(2), {
+    boolean: 'metapackage',
+    alias: {
+        u: 'metapackage',
+    },
+});
 
 for (const root of ROOTS) {
     await $`rm -rf ${root}/node_modules`;
@@ -15,7 +18,7 @@ for (const root of ROOTS) {
 
 await $`rm -rf node_modules`;
 
-if (metapackage) {
+if (flags.metapackage) {
     await $`npm i`;
 } else {
     for (const root of ROOTS) {


### PR DESCRIPTION
This PR slightly simplifies the infra scripts internals:
* delegates options parsing to `minimist`
* aligns scripts behavior for any invocation method: `npx zx script.js`, `node script.js`, `npm run task`
* applies minor readability/syntax improvements