### PR TITLE
feat(pr-digest): filter PRs by creation date, default since 2026-03-01

### DIFF
--- a/scripts/pr-digest/dry-run.mjs
+++ b/scripts/pr-digest/dry-run.mjs
@@ -2,6 +2,7 @@
 /**
  * Dry-run: fetch and classify PRs, print summary without sending to Telegram.
  * Usage: GH_TOKEN=... node dry-run.mjs
+ * Respects DIGEST_SINCE env variable (default: "2026-03-01").
  */
 
 import {classifyPRs, buildMessage} from './core.mjs';
@@ -15,15 +16,16 @@ if (!token) {
     process.exit(1);
 }
 
-console.log('Starting PR digest dry-run...');
+const since = new Date(process.env.DIGEST_SINCE || '2026-03-01T00:00:00Z');
 
-const since = new Date('2026-03-01T00:00:00Z');
+console.log(`Starting PR digest dry-run (since: ${since.toDateString()})...`);
+
 const allPRs = await collectAllPRs({org: ORG, token});
 const prs = allPRs.filter((pr) => new Date(pr.createdAt) >= since);
 console.log(`\nFiltered to PRs created after ${since.toDateString()}: ${prs.length} of ${allPRs.length}`);
 const digest = classifyPRs(prs);
 
-const total = digest.noReview.length + digest.hasIssues.length + digest.awaitingReview.length;
+const total = digest.noReview.length + digest.hasIssues.length + digest.awaitingReview.length + digest.readyToMerge.length;
 
 console.log('\n=== PR Digest Dry Run ===');
 console.log(`Total PRs: ${total}`);

--- a/scripts/pr-digest/index.mjs
+++ b/scripts/pr-digest/index.mjs
@@ -8,6 +8,7 @@
  *   TELEGRAM_BOT_TOKEN    — Telegram Bot API token
  *   TELEGRAM_CHAT_ID      — target chat / group id
  *   GITHUB_TELEGRAM_MAP   — (optional) JSON: { "github-login": "tg_username", … }
+ *   DIGEST_SINCE          — (optional) ISO date to filter PRs created after, default "2026-03-01"
  */
 
 import {classifyPRs, buildMessage, sendTelegram} from './core.mjs';
@@ -36,9 +37,12 @@ async function main() {
         console.warn('Failed to parse GITHUB_TELEGRAM_MAP, ignoring');
     }
 
-    console.log('Starting PR digest...');
+    const since = new Date(process.env.DIGEST_SINCE || '2026-03-01T00:00:00Z');
 
-    const prs = await collectAllPRs({org: ORG, token});
+    console.log(`Starting PR digest (since: ${since.toDateString()})...`);
+
+    const allPRs = await collectAllPRs({org: ORG, token});
+    const prs = allPRs.filter((pr) => new Date(pr.createdAt) >= since);
     const digest = classifyPRs(prs);
     const total = digest.noReview.length + digest.hasIssues.length + digest.awaitingReview.length + digest.readyToMerge.length;
 


### PR DESCRIPTION
## Summary

- Add `DIGEST_SINCE` env variable to show only PRs created after a given date
- Default value: `2026-03-01` — only recent PRs appear in the digest
- `dry-run.mjs` respects the same variable
