### PR TITLE
feat(pr-digest): add Yandex Messenger support

### DIFF
--- a/scripts/pr-digest/core.mjs
+++ b/scripts/pr-digest/core.mjs
@@ -1,5 +1,9 @@
 /**
- * PR Digest Core — shared logic for classification, formatting, and Telegram delivery.
+ * PR Digest Core — shared logic for classification, formatting, and delivery.
+ *
+ * Supports two output formats:
+ *   - 'markdownv2' (default) — Telegram MarkdownV2
+ *   - 'messenger' — Yandex Messenger markdown (**bold**, standard links)
  *
  * Normalized PR format expected by classifyPRs():
  * {
@@ -64,7 +68,7 @@ export function classifyPRs(prs) {
     return {noReview, hasIssues, awaitingReview, readyToMerge};
 }
 
-// ─── message formatting ──────────────────────────────────────────────────────
+// ─── message formatting (Telegram MarkdownV2) ──────────────────────────────
 
 function formatUser(login, tgMap) {
     const tg = tgMap[login];
@@ -127,7 +131,86 @@ function appendSection(lines, emoji, label, prs, tgMap, {showAuthor = false, gro
     }
 }
 
-export function buildMessage({digest, title, tgMap = {}, groupByRepo = false}) {
+// ─── message formatting (Yandex Messenger) ─────────────────────────────────
+
+function msgrFormatUser(login, userMap) {
+    const mapped = userMap[login];
+    return mapped ? `@${mapped}` : login;
+}
+
+function msgrFormatReviewers(reviewers, userMap) {
+    if (reviewers.length === 0) return '-- no reviewers assigned --';
+    return reviewers.map((r) => msgrFormatUser(r, userMap)).join(', ');
+}
+
+function msgrFormatPR(pr, userMap, showAuthor) {
+    const title = `[${pr.title || 'no title'}](${pr.url})`;
+    const author = msgrFormatUser(pr.author, userMap);
+    const age = formatDays(pr.age);
+    const reviewersStr = msgrFormatReviewers(pr.reviewers, userMap);
+
+    if (showAuthor) {
+        const issues = `${pr.openIssues} open / ${pr.resolvedIssues} resolved`;
+        return `* ${title}\n  ${author}  ·  ${age}  ·  ${issues}`;
+    }
+    return `* ${title}\n  ${author}  ·  ${age}  ·  ${reviewersStr}`;
+}
+
+function msgrFormatReadyToMergePR(pr, userMap) {
+    const title = `[${pr.title || 'no title'}](${pr.url})`;
+    const author = msgrFormatUser(pr.author, userMap);
+    const age = formatDays(pr.age);
+    return `* ${title}\n  ${author}  ·  ${age}`;
+}
+
+function msgrAppendSection(lines, emoji, label, prs, userMap, {showAuthor = false, groupByRepo = false, formatFn = null} = {}) {
+    if (!prs.length) return;
+    lines.push(`${emoji} **${label} (${prs.length}):**`);
+    lines.push('');
+
+    const renderPR = formatFn ?? ((pr) => msgrFormatPR(pr, userMap, showAuthor));
+
+    if (groupByRepo) {
+        const byRepo = new Map();
+        for (const pr of prs) {
+            const repo = pr.repo || 'unknown';
+            if (!byRepo.has(repo)) byRepo.set(repo, []);
+            byRepo.get(repo).push(pr);
+        }
+        for (const [repo, repoPrs] of [...byRepo.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+            lines.push(`**${repo}**`);
+            for (const pr of repoPrs) {
+                lines.push(renderPR(pr));
+            }
+            lines.push('');
+        }
+    } else {
+        for (const pr of prs) {
+            lines.push(renderPR(pr));
+            lines.push('');
+        }
+    }
+}
+
+// ─── buildMessage ───────────────────────────────────────────────────────────
+
+/**
+ * Build the digest message.
+ * @param {object} options
+ * @param {object} options.digest - classified PRs from classifyPRs()
+ * @param {string} options.title - message title
+ * @param {object} [options.tgMap] - login → username mapping
+ * @param {boolean} [options.groupByRepo]
+ * @param {'markdownv2'|'messenger'} [options.format] - output format (default: 'markdownv2')
+ */
+export function buildMessage({digest, title, tgMap = {}, groupByRepo = false, format = 'markdownv2'}) {
+    if (format === 'messenger') {
+        return buildMessageMessenger({digest, title, userMap: tgMap, groupByRepo});
+    }
+    return buildMessageTelegram({digest, title, tgMap, groupByRepo});
+}
+
+function buildMessageTelegram({digest, title, tgMap, groupByRepo}) {
     const {noReview, hasIssues, awaitingReview, readyToMerge} = digest;
     const total = noReview.length + hasIssues.length + awaitingReview.length + readyToMerge.length;
     const lines = [];
@@ -145,6 +228,27 @@ export function buildMessage({digest, title, tgMap = {}, groupByRepo = false}) {
     });
 
     lines.push(`Total PRs awaiting attention: *${total}*`);
+    return lines.join('\n');
+}
+
+function buildMessageMessenger({digest, title, userMap, groupByRepo}) {
+    const {noReview, hasIssues, awaitingReview, readyToMerge} = digest;
+    const total = noReview.length + hasIssues.length + awaitingReview.length + readyToMerge.length;
+    const lines = [];
+
+    lines.push(`**📋 ${title}**`);
+    lines.push('');
+
+    const opts = {groupByRepo};
+    msgrAppendSection(lines, '🔴', 'No reviews', noReview, userMap, opts);
+    msgrAppendSection(lines, '🟠', 'Changes requested', hasIssues, userMap, {...opts, showAuthor: true});
+    msgrAppendSection(lines, '🟡', 'Awaiting review', awaitingReview, userMap, opts);
+    msgrAppendSection(lines, '🟢', 'Ready to merge', readyToMerge, userMap, {
+        ...opts,
+        formatFn: (pr) => msgrFormatReadyToMergePR(pr, userMap),
+    });
+
+    lines.push(`Total PRs awaiting attention: **${total}**`);
     return lines.join('\n');
 }
 
@@ -169,5 +273,34 @@ export async function sendTelegram(text, {token, chatId}) {
         throw new Error(`Telegram ${res.status}: ${body}`);
     }
 
-    console.log('Digest sent successfully.');
+    console.log('Telegram: digest sent.');
+}
+
+// ─── yandex messenger ───────────────────────────────────────────────────────
+
+const MESSENGER_API = 'https://bp.mssngr.yandex.net/public';
+
+export async function sendMessenger(text, {token, chatId}) {
+    const authPrefix = token.startsWith('AQAD-') || token.startsWith('y1_') ? 'OAuthTeam' : 'OAuth';
+
+    const res = await fetch(`${MESSENGER_API}/bot/v1/messages/sendText`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `${authPrefix} ${token}`,
+        },
+        body: JSON.stringify({
+            chat_id: chatId,
+            text,
+            disable_web_page_preview: true,
+        }),
+        signal: AbortSignal.timeout(15000),
+    });
+
+    if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(`Messenger ${res.status}: ${body.slice(0, 200)}`);
+    }
+
+    console.log('Messenger: digest sent.');
 }

--- a/scripts/pr-digest/index.mjs
+++ b/scripts/pr-digest/index.mjs
@@ -4,14 +4,16 @@
  * PR Digest entry point for GitHub (diplodoc-platform org).
  *
  * Env variables:
- *   GH_TOKEN              — GitHub API token
- *   TELEGRAM_BOT_TOKEN    — Telegram Bot API token
- *   TELEGRAM_CHAT_ID      — target chat / group id
- *   GITHUB_TELEGRAM_MAP   — (optional) JSON: { "github-login": "tg_username", … }
- *   DIGEST_SINCE          — (optional) ISO date to filter PRs created after, default "2026-03-01"
+ *   GH_TOKEN               — GitHub API token
+ *   TELEGRAM_BOT_TOKEN     — Telegram Bot API token (optional if using Messenger)
+ *   TELEGRAM_CHAT_ID       — target chat / group id
+ *   MESSENGER_OAUTH_TOKEN  — Yandex Messenger OAuth token (optional if using Telegram)
+ *   MESSENGER_CHAT_ID      — Messenger chat ID (required if MESSENGER_OAUTH_TOKEN set)
+ *   GITHUB_TELEGRAM_MAP    — (optional) JSON: { "github-login": "tg_username", … }
+ *   DIGEST_SINCE           — (optional) ISO date to filter PRs created after, default "2026-03-01"
  */
 
-import {classifyPRs, buildMessage, sendTelegram} from './core.mjs';
+import {classifyPRs, buildMessage, sendTelegram, sendMessenger} from './core.mjs';
 import {collectAllPRs} from './github-adapter.mjs';
 
 const ORG = 'diplodoc-platform';
@@ -27,8 +29,16 @@ function env(name, required = true) {
 
 async function main() {
     const token = env('GH_TOKEN');
-    const telegramToken = env('TELEGRAM_BOT_TOKEN');
-    const chatId = env('TELEGRAM_CHAT_ID');
+
+    const tgToken = env('TELEGRAM_BOT_TOKEN', false);
+    const tgChatId = env('TELEGRAM_CHAT_ID', false);
+    const msgrToken = env('MESSENGER_OAUTH_TOKEN', false);
+    const msgrChatId = env('MESSENGER_CHAT_ID', false);
+
+    if (!tgToken && !msgrToken) {
+        console.error('No messaging transport configured. Set TELEGRAM_BOT_TOKEN and/or MESSENGER_OAUTH_TOKEN + MESSENGER_CHAT_ID.');
+        process.exit(1);
+    }
 
     let tgMap = {};
     try {
@@ -51,18 +61,49 @@ async function main() {
         return;
     }
 
-    const message = buildMessage({
-        digest,
-        title: 'PR Digest — diplodoc-platform',
-        tgMap,
-        groupByRepo: true,
-    });
+    const sends = [];
 
-    console.log('--- Message preview ---');
-    console.log(message);
-    console.log('--- End preview ---');
+    if (tgToken && tgChatId) {
+        const message = buildMessage({
+            digest,
+            title: 'PR Digest — diplodoc-platform',
+            tgMap,
+            groupByRepo: true,
+            format: 'markdownv2',
+        });
 
-    await sendTelegram(message, {token: telegramToken, chatId});
+        console.log('--- Telegram message preview ---');
+        console.log(message);
+        console.log('--- End preview ---');
+
+        sends.push(
+            sendTelegram(message, {token: tgToken, chatId: tgChatId})
+                .catch((err) => console.error('Telegram: failed:', err.message)),
+        );
+    }
+
+    if (msgrToken && msgrChatId) {
+        const message = buildMessage({
+            digest,
+            title: 'PR Digest — diplodoc-platform',
+            tgMap,
+            groupByRepo: true,
+            format: 'messenger',
+        });
+
+        if (!tgToken) {
+            console.log('--- Messenger message preview ---');
+            console.log(message);
+            console.log('--- End preview ---');
+        }
+
+        sends.push(
+            sendMessenger(message, {token: msgrToken, chatId: msgrChatId})
+                .catch((err) => console.error('Messenger: failed:', err.message)),
+        );
+    }
+
+    await Promise.all(sends);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

- Add native Yandex Messenger markdown formatting to `core.mjs` — `**bold**`, standard markdown links, no MarkdownV2 escaping
- `buildMessage()` now accepts `format` param: `'markdownv2'` (default, backwards-compatible) or `'messenger'`
- Add `sendMessenger()` to `core.mjs` for sending via Yandex Messenger bot API (`bp.mssngr.yandex.net`)
- Update `index.mjs` for dual transport: Telegram and/or Yandex Messenger, both optional but at least one required

## New env vars

- `MESSENGER_OAUTH_TOKEN` — Yandex Messenger OAuth token
- `MESSENGER_CHAT_ID` — target Messenger chat ID
