### PR TITLE
fix: replace $-refs with explicit versions in react overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,12 +50,12 @@
   },
   "overrides": {
     "@gravity-ui/page-constructor": "8.13.2",
-    "@types/react": "$@types/react",
-    "@types/react-dom": "$@types/react-dom",
+    "@types/react": "^18.2.28",
+    "@types/react-dom": "^18.2.13",
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
-    "react": "$react",
-    "react-dom": "$react-dom"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "dependencies": {
     "@swc/helpers": "^0.5.17",


### PR DESCRIPTION
npm 11.14+ expands `$react` differently depending on the tree node: for the direct devDependency of packages/components it takes the range from the root package.json (^18.2.0), while for the @storybook/react-vite peer edge it takes it from the workspace package.json (^19.2.7). Two conflicting overrides for the same package make `npm i` fail with ERESOLVE in CI. Local npm 11.11 expands both from the root, hence the install passes locally.

Explicit ranges produce the same tree (a single react / react-dom / @types/react on 18) and resolve cleanly on npm 11.5.1 through 11.18.0.